### PR TITLE
docs: correct example comment

### DIFF
--- a/lib/hardware_button_listener.dart
+++ b/lib/hardware_button_listener.dart
@@ -6,12 +6,12 @@ import 'package:hardware_button_listener/models/hardware_button.dart';
 class HardwareButtonListener {
   /// Listens for hardware button events.
   ///
-  /// The stream emits [HardwareButton] instances for  physical pressed buttons
+  /// The stream emits [HardwareButton] instances for physical pressed buttons
   ///
   /// Example usage:
   /// ```dart
   /// final subscription = HardwareButtonListener().listen((event) {
-  ///   print('Button pressed: ${event.type}');
+  ///   print('Button pressed: ${event.buttonName}');
   /// });
   /// ```
   /// Returns a [StreamSubscription] for managing the event stream.


### PR DESCRIPTION
## Summary
- fix example comment in `lib/hardware_button_listener.dart`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d602a11c4832883f5f6b946455678