### PR TITLE
docs: fix QR code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hardware Button Listener
 
-**Hardware Button Listener** is a Flutter package that allows you to listen to physical hardware button presses on Android devices, such as volume buttons or other device-specific keys like devices with attached QRCODE read button.
+**Hardware Button Listener** is a Flutter package that allows you to listen to physical hardware button presses on Android devices, such as volume buttons or other device-specific keys like devices with attached QR code reader button.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- fix a QR code spelling in the intro paragraph

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d6243f2a08328a95d217bfcd72521